### PR TITLE
Regularize audio handling throughout the backend

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions" suppressed-tasks="SCSS" />
+</project>

--- a/backend/app/analysis/encoders.py
+++ b/backend/app/analysis/encoders.py
@@ -4,8 +4,7 @@ Methods for encoding inputted media (image, text)
 import random
 import cv2 as cv
 
-from app.common import SHORT_NOTE_DURATION, LONG_NOTE_DURATION, \
-    NUM_OF_PIANO_KEYS
+from app.common import SHORT_NOTE_DURATION, LONG_NOTE_DURATION, NUM_OF_PIANO_KEYS
 import nltk
 from nltk.sentiment import SentimentIntensityAnalyzer
 

--- a/backend/app/analysis/filters.py
+++ b/backend/app/analysis/filters.py
@@ -9,7 +9,8 @@ import numpy as np
 from scipy.signal import stft  # short time fourier transform
 from scipy.stats import mode
 
-from ..common import NOTE_FREQS, WAV_SAMPLE_RATE
+from app.common import NOTE_FREQS
+from app.audio_encoding import WAV_SAMPLE_RATE
 
 
 def apply_filter(audio_samples, filter_function, **kwargs):

--- a/backend/app/analysis/filters.py
+++ b/backend/app/analysis/filters.py
@@ -468,12 +468,13 @@ def stretch_audio(audio_samples, speed_factor):
     return np.append(new_audio_samples, audio_samples[:num_remaining_samples])
 
 
-# TODO
+# TODO(ra): this isn't  yet implemented
 def overlap_notes(audio_samples, overlap_factor):
     """
     A filter designed to overlap notes within an audio signal.
 
-    :param audio_samples: A tuple containing a 1D NumPy array (of samples) & a Python list of sample indices
+    :param audio_samples: A tuple containing a 1D NumPy array (of samples)
+                          & a Python list of sample indices
     :param overlap_factor:
     A float between 0 and 1 representing the percentage of overlap between notes in the audio,
         relative to the duration of each note (e.g., pass an overlap_factor of `.25` to overlap

--- a/backend/app/analysis/image_to_music.py
+++ b/backend/app/analysis/image_to_music.py
@@ -5,7 +5,7 @@ Methods for taking an image and returning music
 import numpy as np
 import cv2 as cv
 
-from app.audio_encoding import WAV_SAMPLE_RATE, audio_samples_to_wav_base64
+from app.audio_encoding import WAV_SAMPLE_RATE
 from app.analysis import encoders as encode
 from app.analysis import synthesizers as synths
 

--- a/backend/app/analysis/image_to_music.py
+++ b/backend/app/analysis/image_to_music.py
@@ -4,7 +4,8 @@ Methods for taking an image and returning music
 
 import numpy as np
 import cv2 as cv
-from app.common import SAMPLE_CONVERSION_VAL, DEFAULT_SAMPLE_RATE, wav_to_base64
+
+from app.common import WAV_MAX_SAMPLE_AMPLITUDE, WAV_SAMPLE_RATE, wav_to_base64
 from app.analysis import encoders as encode
 from app.analysis import synthesizers as synths
 
@@ -18,9 +19,8 @@ def image_to_note(image):
     note_freq = encode.brightness_to_freq(encode.get_histogram_avg(image))
 
     # get time steps for the sample
-    sample_rate = DEFAULT_SAMPLE_RATE
     note_duration = 1
-    time_steps = np.linspace(0, note_duration, note_duration * sample_rate, False)
+    time_steps = np.linspace(0, note_duration, note_duration * WAV_SAMPLE_RATE, False)
 
     # generate sine wave notes
     note = np.sin(note_freq * time_steps * 2 * np.pi)
@@ -28,7 +28,7 @@ def image_to_note(image):
     # concatenate notes
     audio = note
     # normalize to 16-bit range
-    audio *= SAMPLE_CONVERSION_VAL / np.max(np.abs(audio))
+    audio *= WAV_MAX_SAMPLE_AMPLITUDE / np.max(np.abs(audio))
     # convert to 16-bit data
     audio = audio.astype(np.int16)
     return audio
@@ -41,7 +41,6 @@ def analyze_image(img):
     """
     length_slice = 1 / 60  # in minutes
     num_slices = 5
-    sample_rate = DEFAULT_SAMPLE_RATE
     opencv_im = cv.imdecode(np.frombuffer(img.read(), np.uint8), cv.IMREAD_UNCHANGED)
     instrument = synths.get_instrument(img)
     brightness = encode.get_histogram_avg(opencv_im)
@@ -53,17 +52,17 @@ def analyze_image(img):
     full_audio = []
     for audio_slice in beats_and_durations:
         for _ in range(audio_slice[0]):
-            notes = synths.generate_note(frequency, audio_slice[1], sample_rate)
+            notes = synths.generate_note(frequency, audio_slice[1])
             for harmonic in instrument:
-                notes += synths.generate_note(frequency * harmonic, audio_slice[1], sample_rate)
+                notes += synths.generate_note(frequency * harmonic, audio_slice[1])
 
             full_audio += notes.tolist()
 
     # normalize to 16-bit range
     full_audio = np.array(full_audio)
-    full_audio *= SAMPLE_CONVERSION_VAL / np.max(np.abs(full_audio))
+    full_audio *= WAV_MAX_SAMPLE_AMPLITUDE / np.max(np.abs(full_audio))
 
     # convert to 16-bit data
     full_audio = full_audio.astype(np.int16)
 
-    return wav_to_base64(full_audio, sample_rate)
+    return wav_to_base64(full_audio)

--- a/backend/app/analysis/image_to_music.py
+++ b/backend/app/analysis/image_to_music.py
@@ -5,7 +5,7 @@ Methods for taking an image and returning music
 import numpy as np
 import cv2 as cv
 
-from app.common import WAV_SAMPLE_RATE, wav_samples_to_base64, normalize_audio_to_16_bit_range
+from app.audio_encoding import WAV_SAMPLE_RATE, audio_samples_to_wav_base64
 from app.analysis import encoders as encode
 from app.analysis import synthesizers as synths
 
@@ -25,7 +25,7 @@ def image_to_note(image):
     # generate sine wave notes
     audio = np.sin(note_freq * time_steps * 2 * np.pi)
 
-    return normalize_audio_to_16_bit_range(audio)
+    return audio
 
 
 def analyze_image(img):
@@ -52,5 +52,4 @@ def analyze_image(img):
 
             full_audio += notes.tolist()
 
-    # normalize and base64 encode
-    return wav_samples_to_base64(normalize_audio_to_16_bit_range(full_audio))
+    return full_audio

--- a/backend/app/analysis/image_to_music.py
+++ b/backend/app/analysis/image_to_music.py
@@ -5,7 +5,7 @@ Methods for taking an image and returning music
 import numpy as np
 import cv2 as cv
 
-from app.common import WAV_MAX_SAMPLE_AMPLITUDE, WAV_SAMPLE_RATE, wav_to_base64
+from app.common import WAV_SAMPLE_RATE, wav_samples_to_base64, normalize_audio_to_16_bit_range
 from app.analysis import encoders as encode
 from app.analysis import synthesizers as synths
 
@@ -13,7 +13,7 @@ from app.analysis import synthesizers as synths
 def image_to_note(image):
     """
     :param image:
-    :return _wav_to_base64(audio, sample_rate):
+    :return audio: audio samples
         base64 encoding of a sound based on how negative or positive the text is
     """
     note_freq = encode.brightness_to_freq(encode.get_histogram_avg(image))
@@ -23,15 +23,9 @@ def image_to_note(image):
     time_steps = np.linspace(0, note_duration, note_duration * WAV_SAMPLE_RATE, False)
 
     # generate sine wave notes
-    note = np.sin(note_freq * time_steps * 2 * np.pi)
+    audio = np.sin(note_freq * time_steps * 2 * np.pi)
 
-    # concatenate notes
-    audio = note
-    # normalize to 16-bit range
-    audio *= WAV_MAX_SAMPLE_AMPLITUDE / np.max(np.abs(audio))
-    # convert to 16-bit data
-    audio = audio.astype(np.int16)
-    return audio
+    return normalize_audio_to_16_bit_range(audio)
 
 
 def analyze_image(img):
@@ -58,11 +52,5 @@ def analyze_image(img):
 
             full_audio += notes.tolist()
 
-    # normalize to 16-bit range
-    full_audio = np.array(full_audio)
-    full_audio *= WAV_MAX_SAMPLE_AMPLITUDE / np.max(np.abs(full_audio))
-
-    # convert to 16-bit data
-    full_audio = full_audio.astype(np.int16)
-
-    return wav_to_base64(full_audio)
+    # normalize and base64 encode
+    return wav_samples_to_base64(normalize_audio_to_16_bit_range(full_audio))

--- a/backend/app/analysis/synthesizers.py
+++ b/backend/app/analysis/synthesizers.py
@@ -118,7 +118,6 @@ def generate_note(frequency, duration):
     all_weights = np.array(a_weights + d_weights + s_weights + r_weights)
     time_steps = np.linspace(0, duration, (len_a + len_d + len_s + len_r), False)
     note = np.sin(frequency * time_steps * 2 * np.pi) * all_weights
-    # note *= 32767 / np.max(np.abs(note))
 
     return note
 

--- a/backend/app/analysis/synthesizers.py
+++ b/backend/app/analysis/synthesizers.py
@@ -6,7 +6,7 @@ import random
 import numpy as np
 from colorthief import ColorThief
 from app.common import MUSICAL_CHARS, NOTE_FREQ_SIMPLE, DISSONANT_RATIOS, NEUTRAL_RATIOS, \
-    CONSONANT_RATIOS, DEFAULT_SAMPLE_RATE, SAMPLE_CONVERSION_VAL, lookup_note_frequency
+    CONSONANT_RATIOS, WAV_SAMPLE_RATE, WAV_MAX_SAMPLE_AMPLITUDE, lookup_note_frequency
 
 mc_list = list(MUSICAL_CHARS)
 
@@ -84,7 +84,7 @@ def calculate_note_frequency(base_frequency, rounding_frequency, positivity_diff
     return base_frequency + positivity_differential * rounding_frequency * neutral_score
 
 
-def generate_note(frequency, duration, sample_rate):
+def generate_note(frequency, duration):
     # pylint: disable-msg=R0914
     """
     Uses the ADSR (Attack, Decay, Sustain, Release) envelope to
@@ -92,18 +92,18 @@ def generate_note(frequency, duration, sample_rate):
     Adapted from example in https://towardsdatascience.com/music-in-python-2f054deb41f4
     :param frequency: frequency of the note
     :param duration: duration in seconds
-    :param sample_rate: sampling rate
     :return note: list of samples for the note
     """
-    a_percentage = 0.1
-    d_percentage = 0.1
-    s_percentage = 0.1
-    r_percentage = 0.7
+    # TODO(ra): these should all be params that we can modify in a call
+    a_percentage = 0.1  # attack
+    d_percentage = 0.1  # decay
+    s_percentage = 0.1  # sustain
+    r_percentage = 0.7  # release
     peak_weight = 1
     sustain_weight = 0.7
     final_weight = 0
 
-    total_length = duration * sample_rate
+    total_length = duration * WAV_SAMPLE_RATE
     len_a = int(a_percentage * total_length)
     len_d = int(d_percentage * total_length)
     len_s = int(s_percentage * total_length)
@@ -170,13 +170,12 @@ def get_notes_from_text(text):
     return notes
 
 
-def sonify(notes, durations, sentiment, sample_rate):
+def sonify(notes, durations, sentiment):
     """
     Takes in list of notes, durations, and sentiment, and returns audio
     :param notes: List of floats
     :param durations: Corresponding list of durations for notes
     :param sentiment: Dict of sentiment values
-    :param sample_rate: Integer, the sampling rate
     :return audio: List of samples for collection of notes
     """
     quieter_note_loudness = 0.6
@@ -187,7 +186,7 @@ def sonify(notes, durations, sentiment, sample_rate):
         louder_note_freq = lookup_note_frequency(notes[index])
         quieter_note_freq = get_note_frequency(sentiment, louder_note_freq)
 
-        time_steps = np.linspace(0, duration, int(duration * sample_rate), False)
+        time_steps = np.linspace(0, duration, int(duration * WAV_SAMPLE_RATE), False)
         louder_note = np.sin(louder_note_freq * time_steps * 2 * np.pi).tolist()
         quieter_note = np.sin(quieter_note_freq * time_steps * 2 * np.pi).tolist()
 
@@ -212,11 +211,10 @@ def convert_piano_key_num_to_sin_wave(piano_key):
     """
     a4_note = NOTE_FREQ_SIMPLE['a']
     duration = 1
-    sample_rate = DEFAULT_SAMPLE_RATE
-    time_axis = np.linspace(0, duration, duration * sample_rate, False)
+    time_axis = np.linspace(0, duration, duration * WAV_SAMPLE_RATE, False)
     frequency = a4_note * (2 ** ((piano_key + 1 - 49) / 12))
     sin_wave = np.sin(2 * np.pi * frequency * time_axis)
-    return sin_wave, sample_rate
+    return sin_wave
 
 
 def convert_sin_waves_to_audio(sin_waves):
@@ -225,7 +223,6 @@ def convert_sin_waves_to_audio(sin_waves):
     :return audio
     """
     audio = np.hstack(sin_waves)
-    audio *= SAMPLE_CONVERSION_VAL / np.max(np.abs(audio))
+    audio *= WAV_MAX_SAMPLE_AMPLITUDE / np.max(np.abs(audio))
     audio = audio.astype(np.int16)
-
     return audio

--- a/backend/app/analysis/synthesizers.py
+++ b/backend/app/analysis/synthesizers.py
@@ -10,7 +10,7 @@ from app.common import (
     CONSONANT_RATIOS, lookup_note_frequency
 )
 
-from app.audio_encoding import WAV_SAMPLE_RATE, WAV_MAX_SAMPLE_AMPLITUDE
+from app.audio_encoding import WAV_SAMPLE_RATE
 
 
 mc_list = list(MUSICAL_CHARS)

--- a/backend/app/analysis/synthesizers.py
+++ b/backend/app/analysis/synthesizers.py
@@ -5,8 +5,13 @@ Methods for turning data into sound!
 import random
 import numpy as np
 from colorthief import ColorThief
-from app.common import MUSICAL_CHARS, NOTE_FREQ_SIMPLE, DISSONANT_RATIOS, NEUTRAL_RATIOS, \
-    CONSONANT_RATIOS, WAV_SAMPLE_RATE, WAV_MAX_SAMPLE_AMPLITUDE, lookup_note_frequency
+from app.common import (
+    MUSICAL_CHARS, NOTE_FREQ_SIMPLE, DISSONANT_RATIOS, NEUTRAL_RATIOS,
+    CONSONANT_RATIOS, lookup_note_frequency
+)
+
+from app.audio_encoding import WAV_SAMPLE_RATE, WAV_MAX_SAMPLE_AMPLITUDE
+
 
 mc_list = list(MUSICAL_CHARS)
 
@@ -214,14 +219,3 @@ def convert_piano_key_num_to_sin_wave(piano_key):
     frequency = a4_note * (2 ** ((piano_key + 1 - 49) / 12))
     sin_wave = np.sin(2 * np.pi * frequency * time_axis)
     return sin_wave
-
-
-def convert_sin_waves_to_audio(sin_waves):
-    """
-    :param sin_waves: a list of sin waves
-    :return audio
-    """
-    audio = np.hstack(sin_waves)
-    audio *= WAV_MAX_SAMPLE_AMPLITUDE / np.max(np.abs(audio))
-    audio = audio.astype(np.int16)
-    return audio

--- a/backend/app/analysis/text_to_music.py
+++ b/backend/app/analysis/text_to_music.py
@@ -4,7 +4,8 @@ Transform text to sound
 import numpy as np
 from nltk.tokenize import sent_tokenize
 
-from app.common import WAV_SAMPLE_RATE, clean_text, normalize_audio_to_16_bit_range
+from app.common import clean_text
+from app.audio_encoding import WAV_SAMPLE_RATE
 from app.analysis import encoders as encode
 from app.analysis import synthesizers as synths
 
@@ -33,7 +34,7 @@ def text_to_note(text):
 
     # generate sine wave notes
     audio = np.sin(note_frequency * time_steps * 2 * np.pi)
-    return normalize_audio_to_16_bit_range(audio)
+    return audio
 
 
 def sonify_text(text):
@@ -52,7 +53,7 @@ def sonify_text(text):
 
         full_audio += synths.sonify(notes, durations, sentiment)
 
-    return normalize_audio_to_16_bit_range(full_audio)
+    return full_audio
 
 
 def sonify_text_2(text):
@@ -73,5 +74,5 @@ def sonify_text_2(text):
         sin_wave = synths.convert_piano_key_num_to_sin_wave(piano_key)
         sin_waves_list.append(sin_wave)
 
-    audio = synths.convert_sin_waves_to_audio(sin_waves_list)
+    audio = np.hstack(sin_waves_list)
     return audio

--- a/backend/app/audio_encoding.py
+++ b/backend/app/audio_encoding.py
@@ -1,0 +1,73 @@
+"""
+Throughout our project, on the backend we handle audio as numpy arrays of amplitudes of a waveform.
+We use 44100 samples per second (44.1 kHz), but the amplitude of each sample is unbounded.
+
+This module handles transformation from that numpy array into a WAV file,
+which involves normalizing the amplitude to the range of a 16-bit integer.
+
+It also handles base64 encoding that WAV file, so we can send it to the frontend as part
+of our JSON payload.
+
+For more information on what's going on here, check out:
+https://wiki.hydrogenaud.io/index.php?title=Sampling_rate
+for a nice visualization of how a WAV file represents a sound wave.
+
+See also:
+https://docs.fileformat.com/audio/wav/
+for the anatomy of a WAV file
+"""
+
+import base64
+import io
+import numpy as np
+from scipy.io import wavfile
+
+# We assume 44100 samples per second throughout our project,
+# which is the standard sample rate for CD audio.
+WAV_SAMPLE_RATE = 44100
+# 16-bit audio has a max amplitude of 32767 per sample,
+# which is the maximum value of a 16-bit signed integer
+WAV_MAX_SAMPLE_AMPLITUDE = 32767
+
+
+def normalize_audio_samples_to_16_bit_range(audio):
+    # TODO(ra): test me!
+    normalized_audio = audio / np.max(np.abs(audio))      # normalize samples from 0 to 1
+    normalized_audio *= WAV_MAX_SAMPLE_AMPLITUDE          # Normalize to 16-bit WAV sample range
+    normalized_audio = normalized_audio.astype(np.int16)  # tell numpy that this is 16-bit int data
+    return normalized_audio
+
+
+def audio_samples_to_wav_base64(audio_samples):
+    """
+    This is the public interface to _wav_samples_to_base64, which does the actual work of
+    base64 encoding our WAV samples. This function adds the assumption that we're using our
+    default, 44.1 kHz sample rate, and normalizes each sample to the 16-bit amplitude range.
+
+    :param audio_samples: 1D NumPy array representing the list of samples
+    """
+    normalized_audio_samples = normalize_audio_samples_to_16_bit_range(audio_samples)
+    return _audio_samples_to_wav_base64(normalized_audio_samples, WAV_SAMPLE_RATE)
+
+
+def _audio_samples_to_wav_base64(audio_samples, sample_rate):
+    """
+    Encode the WAV byte array into a base64 encoded WAV file that we can send to the frontend.
+
+    NOTE(ra): We have this private version of this function where we take the sample rate
+              as an argument, rather than assuming 44.1 kHz in order to be able
+              to write human-readable, sensible tests. (See tests.WavToBase64TestCase)
+
+              The public interface to this is the above function wav_samples_to_base64, which
+              assumes 44.1 kHz sampling.
+
+    :param audio: NumPy array representing the list of samples.
+    :param sample_rate: int, the sampling rate in Hz
+    :return: base64 encoding of the given array as a str
+    """
+    byte_io = io.BytesIO(bytes())  # bytes buffer to write into
+    wavfile.write(byte_io, sample_rate, audio_samples)  # write audio into this buffer in WAV format
+    wav_bytes = byte_io.read()  # read the buffer
+    base64_wav = base64.b64encode(wav_bytes)  # base64 encode the wav file
+    utf8_base64_wav = base64_wav.decode('UTF-8')  # UTF-8 decode the base64 encoded wav file
+    return utf8_base64_wav

--- a/backend/app/audio_encoding.py
+++ b/backend/app/audio_encoding.py
@@ -30,10 +30,16 @@ WAV_SAMPLE_RATE = 44100
 WAV_MAX_SAMPLE_AMPLITUDE = 32767
 
 
-def normalize_audio_samples_to_16_bit_range(audio):
+def normalize_audio_samples_to_16_bit_range(audio_samples):
+    """
+    Normalizes the input audio samples to the 16-bit range for WAV file output.
+
+    :param audio_samples: 1D numpy array of audio samples
+    :return: normalized_audio: 1D numpy array of audio samples in 16-bit range
+    """
     # TODO(ra): test me!
-    normalized_audio = audio / np.max(np.abs(audio))      # normalize samples from 0 to 1
-    normalized_audio *= WAV_MAX_SAMPLE_AMPLITUDE          # Normalize to 16-bit WAV sample range
+    normalized_audio = audio_samples / np.max(np.abs(audio_samples))  # normalize from 0 to 1
+    normalized_audio *= WAV_MAX_SAMPLE_AMPLITUDE  # Normalize to 16-bit WAV sample range
     normalized_audio = normalized_audio.astype(np.int16)  # tell numpy that this is 16-bit int data
     return normalized_audio
 

--- a/backend/app/common.py
+++ b/backend/app/common.py
@@ -1,73 +1,8 @@
 """
 Miscellaneous utility functions useful throughout the system
 """
-import base64
-import io
-import numpy as np
 import string
 from textwrap import dedent
-from scipy.io import wavfile
-
-
-################################################################################
-# WAV file values
-################################################################################
-# We assume 44100 samples per second throughout our project,
-# which is the standard sample rate for CD audio.
-WAV_SAMPLE_RATE = 44100
-# 16-bit audio has a max amplitude of 32767 per sample,
-# which is the maximum value of a 16-bit signed integer
-WAV_MAX_SAMPLE_AMPLITUDE = 32767
-# See https://wiki.hydrogenaud.io/index.php?title=Sampling_rate for a nice visualization
-# of how a WAV file represents a sound wave.
-# See also https://docs.fileformat.com/audio/wav/ for the anatomy of a WAV file
-
-
-def wav_samples_to_base64(audio):
-    """
-    This is the public interface to _wav_samples_to_base64, which does the actual work of base64 encoding
-    our WAV samples. This function adds the assumption that we're using our default,
-    44.1 kHz sample rate.
-
-    :param audio: 1D NumPy array representing the list of samples
-    """
-    return _wav_samples_to_base64(audio, WAV_SAMPLE_RATE)
-
-
-def _wav_samples_to_base64(audio, sample_rate):
-    """
-    Encode the WAV byte array into a base64 encoded WAV file that we can send to the frontend.
-
-    NOTE(ra): We have this private version of this function where we take the sample rate
-              as an argument, rather than assuming 44.1 kHz in order to be able
-              to write human-readable, sensible tests. (See tests.WavToBase64TestCase)
-
-              The public interface to this is the above function wav_samples_to_base64, which
-              assumes 44.1 kHz sampling.
-
-    :param audio: NumPy array representing the list of samples (usually int16: 2 bytes/sample)
-    :param sample_rate: int, the sampling rate in Hz
-    :return: base64 encoding of the given array as a str
-    """
-    byte_io = io.BytesIO(bytes())  # bytes buffer to write into
-    wavfile.write(byte_io, sample_rate, audio)  # write audio into this buffer in WAV format
-    wav_bytes = byte_io.read()  # read the buffer
-    base64_wav = base64.b64encode(wav_bytes)  # base64 encode the wav file
-    utf8_base64_wav = base64_wav.decode('UTF-8')  # UTF-8 decode the base64 encoded wav file
-    return utf8_base64_wav
-
-
-def normalize_audio_to_16_bit_range(audio):
-    # normalize 0 to 1
-    normalized_audio = audio / np.max(np.abs(audio))
-
-    # Normalize to 16-bit WAV sample range
-    normalized_audio *= WAV_MAX_SAMPLE_AMPLITUDE
-
-    # Let numpy know that this is 16-bit integer data
-    normalized_audio = normalized_audio.astype(np.int16)
-
-    return normalized_audio
 
 
 

--- a/backend/app/common.py
+++ b/backend/app/common.py
@@ -7,9 +7,20 @@ import string
 from textwrap import dedent
 from scipy.io import wavfile
 
-# reference: https://wiki.hydrogenaud.io/index.php?title=Sampling_rate
-SAMPLE_CONVERSION_VAL = 32767
-DEFAULT_SAMPLE_RATE = 44100
+
+################################################################################
+# WAV file values
+################################################################################
+# We assume 44100 samples per second throughout our project,
+# which is the standard sample rate for CD audio.
+WAV_SAMPLE_RATE = 44100
+# 16-bit audio has a max amplitude of 32767 per sample,
+# which is the maximum value of a 16-bit signed integer
+WAV_MAX_SAMPLE_AMPLITUDE = 32767
+# See https://wiki.hydrogenaud.io/index.php?title=Sampling_rate for a nice visualization
+# of how a WAV file represents a sound wave.
+
+
 MUSICAL_CHARS = {'a', 'b', 'c', 'd', 'e', 'f', 'g'}
 
 # Ratios found from Wikipedia https://tinyurl.com/56cj5rh5 (wiki link that's too long)
@@ -146,7 +157,7 @@ NOTE_FREQ_SIMPLE = {
 }
 
 
-def wav_to_base64(byte_array, sample_rate):
+def wav_to_base64(byte_array):
     """
     Encode the WAV byte array with base64
     :param byte_array: NumPy array representing the list of samples (usually int16: 2 bytes/sample)
@@ -154,7 +165,7 @@ def wav_to_base64(byte_array, sample_rate):
     :return: base64 encoding of the given array as a str
     """
     byte_io = io.BytesIO(bytes())
-    wavfile.write(byte_io, sample_rate, byte_array)
+    wavfile.write(byte_io, WAV_SAMPLE_RATE, byte_array)
     wav_bytes = byte_io.read()
     audio_data = base64.b64encode(wav_bytes).decode('UTF-8')
     return audio_data

--- a/backend/app/tests.py
+++ b/backend/app/tests.py
@@ -2,7 +2,7 @@
 Tests for the sonification web app.
 """
 # pylint: disable-msg=C0116
-# ignoring pylint's `missing-function-docstring` errors
+# ignoring pylint's `missing-function-docstring` errors just for tests
 import io
 import base64
 import cv2 as cv

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -32,7 +32,7 @@ from django.shortcuts import render
 from app.analysis.image_to_music import analyze_image
 
 from app.analysis.text_to_music import text_to_note, sonify_text, sonify_text_2
-from app.common import wav_to_base64
+from app.common import wav_samples_to_base64
 
 
 @api_view(['GET'])
@@ -139,7 +139,7 @@ def get_sentiment_analysis(request):
     # audio_data = filters.apply_filter(audio_data, filters.add_chords)
     # audio_data = filters.apply_filter(audio_data, filters.stretch_audio, speed_factor=.5)
 
-    encoded_audio = wav_to_base64(*audio_data)
+    encoded_audio = wav_samples_to_base64(audio_data)
 
     res = {
         'sound': encoded_audio
@@ -156,8 +156,8 @@ def get_sentiment_analysis_2(request):
     note = text_to_note(text)
     sound = sonify_text(text)
     res = {
-        'note': wav_to_base64(*note),
-        'sound': wav_to_base64(*sound)
+        'note': wav_samples_to_base64(note),
+        'sound': wav_samples_to_base64(sound)
     }
     return Response(res)
 

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -27,13 +27,9 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from django.shortcuts import render
 
-# from .analysis import filters
-
 from app.analysis.image_to_music import analyze_image
-
 from app.analysis.text_to_music import text_to_note, sonify_text, sonify_text_2
-from app.common import wav_samples_to_base64
-
+from app.audio_encoding import audio_samples_to_wav_base64
 
 @api_view(['GET'])
 def get_example(request, api_example_id):
@@ -139,10 +135,8 @@ def get_sentiment_analysis(request):
     # audio_data = filters.apply_filter(audio_data, filters.add_chords)
     # audio_data = filters.apply_filter(audio_data, filters.stretch_audio, speed_factor=.5)
 
-    encoded_audio = wav_samples_to_base64(audio_data)
-
     res = {
-        'sound': encoded_audio
+        'sound': audio_samples_to_wav_base64(audio_data)
     }
     return Response(res)
 
@@ -156,8 +150,8 @@ def get_sentiment_analysis_2(request):
     note = text_to_note(text)
     sound = sonify_text(text)
     res = {
-        'note': wav_samples_to_base64(note),
-        'sound': wav_samples_to_base64(sound)
+        'note': audio_samples_to_wav_base64(note),
+        'sound': audio_samples_to_wav_base64(sound)
     }
     return Response(res)
 
@@ -184,6 +178,6 @@ def image_to_music(request):
     image = request.data['image']
     audio = analyze_image(image)
     res = {
-        'sound': audio
+        'sound': audio_samples_to_wav_base64(audio)
     }
     return Response(res)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -17,10 +17,7 @@ Including another URL configuration
 from django.contrib import admin
 from django.urls import path
 
-try:
-    from ..app import views
-except (ImportError, ModuleNotFoundError):
-    from app import views
+from app import views
 
 urlpatterns = [
     # Django admin page

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,7 +1,10 @@
+// Libraries
 import React from "react";
 import ReactDOM from "react-dom";
-import "./scss/index.scss";
 import "bootstrap/dist/css/bootstrap.min.css";
+
+// Our imports
+import "./scss/index.scss";
 import Base from "./components/global/Base";
 import ErrorNotFoundComponent from "./components/ErrorNotFoundComponent";
 import ExampleId from "./components/ExampleId";
@@ -9,11 +12,8 @@ import SentimentAnalysis from "./components/SentimentAnalysis";
 import SentimentAnalysis2 from "./components/SentimentAnalysis2";
 import Home from "./components/Home";
 import ImageAnalysis from "./components/ImageAnalysis";
-const COMPONENT_PROPS_RAW = document.getElementById("component_props").text;
-const COMPONENT_NAME_RAW = document.getElementById("component_name").text;
-const COMPONENT_PROPS = JSON.parse(COMPONENT_PROPS_RAW);
-const COMPONENT_NAME = JSON.parse(COMPONENT_NAME_RAW);
 
+// Register each new view component here
 const COMPONENTS = {
     ErrorNotFoundComponent,
     ExampleId,
@@ -22,6 +22,13 @@ const COMPONENTS = {
     ImageAnalysis,
     Home
 };
+
+// Here, we take the data for our components specified by Django in our views.py file,
+// and we parse it to hand off to React
+const COMPONENT_PROPS_RAW = document.getElementById("component_props").text;
+const COMPONENT_NAME_RAW = document.getElementById("component_name").text;
+const COMPONENT_PROPS = JSON.parse(COMPONENT_PROPS_RAW);
+const COMPONENT_NAME = JSON.parse(COMPONENT_NAME_RAW);
 
 const PreselectedComponent = COMPONENTS[COMPONENT_NAME || "ErrorNotFoundComponent"];
 


### PR DESCRIPTION
This PR regularizes audio handling throughout the backend of our project. Previously, various systems expected audio in a bunch of different formats. Now the expectation is that all audio on the backend is stored as a buffer of samples at 44100 Hz, without any expectation of normalized amplitude. They're all numpy arrays, too.

We handle normalization into 16-bit range at the last possible moment (before sending to the frontend, in the Django view function).

We set 44.1 kHz as the default sample rate and use it everywhere, so we don't have to constantly be handling sample rate conversion throughout the project. It's probably a bit overkill, but we can always adjust later.

See `audio_encoding.py` for the bulk of the work. This code was all in the project already—this is largely a refactor and cleanup.

Also regularizes terminology. Audio is always referred to as `audio_samples` so it's clearer what the data structure is.