### PR TITLE
Color Encoding to Sound v2 (cherry picked merge fix)

### DIFF
--- a/backend/app/api_views.py
+++ b/backend/app/api_views.py
@@ -18,27 +18,49 @@ def color(request):
     :param request: colorpicker's rgb values stored as a dictionary when the user hits submit
     :return: wav file, sine wave with frequency corresponds to energy of the color
     """
-    response_object = request.data['listOfColors'][0]
-    r = response_object["r"]
-    g = response_object["g"]
-    b = response_object["b"]
-    energy = round(0.299*r + .587*g + .114*b) # color energy calculation
+    response_object = request.data['listOfColors']
+    # r = response_object["r"]
+    # g = response_object["g"]
+    # b = response_object["b"]
+    # energy = round(0.299*r + .587*g + .114*b) # color energy calculation
+    #
+    # freq_to_generate = ((200*energy) / 255 ) + 150 # frequency based on energy, scaled for 150-350hz
+    # audio_samples = synths.generate_sine_wave_with_envelope(
+    #     frequency=freq_to_generate,
+    #     duration=500,
+    #     a_percentage=0,
+    #     d_percentage=0,
+    #     s_percentage=1,
+    #     r_percentage=0
+    # )
+    # wav_file_base64 = audio_samples_to_wav_base64(audio_samples)
+    #
+    # # return Response({
+    # #     "text": str(energy)
+    # # })
+    # return Response([wav_file_base64])
 
-    freq_to_generate = ((200*energy) / 255 ) + 150 # frequency based on energy, scaled for 150-350hz
-    audio_samples = synths.generate_sine_wave_with_envelope(
-        frequency=freq_to_generate,
-        duration=500,
-        a_percentage=0,
-        d_percentage=0,
-        s_percentage=1,
-        r_percentage=0
-    )
-    wav_file_base64 = audio_samples_to_wav_base64(audio_samples)
+    wav_files = []
+    for response in response_object:
+        r = response["r"]
+        g = response["g"]
+        b = response["b"]
+        energy = round(0.299 * r + .587 * g + .114 * b)  # color energy calculation
 
-    # return Response({
-    #     "text": str(energy)
-    # })
-    return Response([wav_file_base64])
+        freq_to_generate = ((200 * energy) / 255) + 150  # frequency based on energy, scaled for 150-350hz
+
+        audio_samples = synths.generate_sine_wave_with_envelope(
+            frequency=freq_to_generate,
+            duration=500,
+            a_percentage=0,
+            d_percentage=0,
+            s_percentage=1,
+            r_percentage=0
+        )
+        wav_file_base64 = audio_samples_to_wav_base64(audio_samples)
+        wav_files.append(wav_file_base64)
+
+    return Response(wav_files)
 
 
 @api_view(['POST'])

--- a/backend/app/api_views.py
+++ b/backend/app/api_views.py
@@ -51,7 +51,7 @@ def color(request):
 
         audio_samples = synths.generate_sine_wave_with_envelope(
             frequency=freq_to_generate,
-            duration=500,
+            duration=50,
             a_percentage=0,
             d_percentage=0,
             s_percentage=1,

--- a/backend/app/api_views.py
+++ b/backend/app/api_views.py
@@ -18,7 +18,7 @@ def color(request):
     :param request: colorpicker's rgb values stored as a dictionary when the user hits submit
     :return: wav file, sine wave with frequency corresponds to energy of the color
     """
-    response_object = request.data['color']
+    response_object = request.data['listOfColors'][0]
     r = response_object["r"]
     g = response_object["g"]
     b = response_object["b"]

--- a/backend/app/api_views.py
+++ b/backend/app/api_views.py
@@ -19,35 +19,18 @@ def color(request):
     :return: wav file, sine wave with frequency corresponds to energy of the color
     """
     response_object = request.data['listOfColors']
-    # r = response_object["r"]
-    # g = response_object["g"]
-    # b = response_object["b"]
-    # energy = round(0.299*r + .587*g + .114*b) # color energy calculation
-    #
-    # freq_to_generate = ((200*energy) / 255 ) + 150 # frequency based on energy, scaled for 150-350hz
-    # audio_samples = synths.generate_sine_wave_with_envelope(
-    #     frequency=freq_to_generate,
-    #     duration=500,
-    #     a_percentage=0,
-    #     d_percentage=0,
-    #     s_percentage=1,
-    #     r_percentage=0
-    # )
-    # wav_file_base64 = audio_samples_to_wav_base64(audio_samples)
-    #
-    # # return Response({
-    # #     "text": str(energy)
-    # # })
-    # return Response([wav_file_base64])
 
     wav_files = []
     for response in response_object:
         r = response["r"]
         g = response["g"]
         b = response["b"]
-        energy = round(0.299 * r + .587 * g + .114 * b)  # color energy calculation
 
-        freq_to_generate = ((200 * energy) / 255) + 150  # frequency based on energy, scaled for 150-350hz
+        # color energy calculation
+        energy = round(0.299 * r + .587 * g + .114 * b)
+
+        # frequency based on energy, scaled for 150-350hz
+        freq_to_generate = ((200 * energy) / 255) + 150
 
         audio_samples = synths.generate_sine_wave_with_envelope(
             frequency=freq_to_generate,

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -59,7 +59,7 @@ class BasePage extends React.Component {
     }
 
     handlePaletteClick = (e) => {
-        this.setState({ selected: e.target.id });
+        this.setState({ selected: Number(e.target.id) });
     }
 
     handleChangeComplete = (color) => {
@@ -82,9 +82,12 @@ class BasePage extends React.Component {
 
     render() {
         const colorDisplay = this.state.listOfColors.map( (color, i) =>
-            <div key={i}>
-                <PaletteColor id={i} color={color} selected={false} handlePaletteClick={this.handlePaletteClick}/>
-            </div>
+            {console.log("i", i);
+                console.log("selected", this.state.selected);
+                return (<div key={i}>
+                    <PaletteColor id={i} color={color} selected={i===Number(this.state.selected)} handlePaletteClick={this.handlePaletteClick}/>
+                </div>);
+            }
         );
         return (<div>
             <h1> Color Encoding to Sound </h1>

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -82,12 +82,9 @@ class BasePage extends React.Component {
 
     render() {
         const colorDisplay = this.state.listOfColors.map( (color, i) =>
-            {console.log("i", i);
-                console.log("selected", this.state.selected);
-                return (<div key={i}>
+            <div key={i}>
                     <PaletteColor id={i} color={color} selected={i===Number(this.state.selected)} handlePaletteClick={this.handlePaletteClick}/>
-                </div>);
-            }
+            </div>
         );
         return (<div>
             <h1> Color Encoding to Sound </h1>

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -10,13 +10,9 @@ class BasePage extends React.Component {
 
         this.handlePaletteClick = this.handlePaletteClick.bind(this);
         this.state = {
-            color: {
-                r: 51,
-                g: 51,
-                b: 51,
-            },
             result: [],
             selected: 0,
+            instrumentGenerated: false,
             listOfColors: [
                 {
                     r: 0,
@@ -68,12 +64,11 @@ class BasePage extends React.Component {
     };
 
     handleSubmit = () => {
-        const requestBody = {color: this.state.color};
+        const requestBody = {listOfColors: this.state.listOfColors};
         const responseCallbackFunc = responseDict => {
-            const tempColor = this.state.color;
             this.setState({
                 result: responseDict,
-                listOfColors: this.state.listOfColors.concat(tempColor),
+                instrumentGenerated: true
             });
             console.log(this.state.listOfColors);
         };
@@ -94,10 +89,8 @@ class BasePage extends React.Component {
             <SketchPicker
                 color={this.state.color}
                 onChangeComplete={this.handleChangeComplete}
+                disableAlpha
             />
-            {/*<button onClick={this.handleSubmit}>*/}
-            {/*    Submit*/}
-            {/*</button>*/}
 
             {/*<audio controls controlsList={"nodownload"}>*/}
             {/*        <source src={`data:audio/wav;base64,${this.state.result}`} type={"audio/wav"}/>*/}
@@ -106,11 +99,15 @@ class BasePage extends React.Component {
             {/*       src={`data:audio/wav;base64, ${this.state.result}`}*/}
             {/*       controlsList="nodownload"/>*/}
 
-            {/*<SliderInstrument*/}
-            {/*    samples={this.state.result}*/}
-            {/*/>*/}
-
             { colorDisplay }
+
+            <button onClick={this.handleSubmit}>
+                {this.state.instrumentGenerated ? "Update Instrument" : "Generate Instrument"}
+            </button>
+
+            {this.state.result.length !== 0 && <SliderInstrument
+                samples={this.state.result}
+            />}
         </div>);
     }
 };

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -89,7 +89,7 @@ class BasePage extends React.Component {
         return (<div>
             <h1> Color Encoding to Sound </h1>
             <p> Use the color picker below to choose a color, and hit the <b>submit</b> button
-            to add up to (max) colors to your palette. When you're ready to  hear them together,
+            to add up to seven colors to your palette. When you're ready to  hear them together,
             click the <b>Generate Instrument</b> button to hear them together!</p>
             <div className="row">
                 <SketchPicker

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -13,6 +13,11 @@ class BasePage extends React.Component {
             result: [],
             selected: 0,
             instrumentGenerated: false,
+            colorPickerColor: {
+                    r: 51,
+                    g: 51,
+                    b: 51,
+            },
             listOfColors: [
                 {
                     r: 0,
@@ -60,7 +65,7 @@ class BasePage extends React.Component {
     handleChangeComplete = (color) => {
         const currentColorState = [ ...this.state.listOfColors ];
         currentColorState[this.state.selected] = color.rgb;
-        this.setState({ listOfColors: [ ...currentColorState ] });
+        this.setState({ listOfColors: [ ...currentColorState ], colorPickerColor: color.rgb });
     };
 
     handleSubmit = () => {
@@ -70,7 +75,7 @@ class BasePage extends React.Component {
                 result: responseDict,
                 instrumentGenerated: true
             });
-            console.log(this.state.listOfColors);
+            // console.log(this.state.listOfColors);
         };
         fetchPost('/api/color/', requestBody, responseCallbackFunc);
     };
@@ -88,7 +93,7 @@ class BasePage extends React.Component {
             click the <b>Generate Instrument</b> button to hear them together!</p>
             <div className="row">
                 <SketchPicker
-                    color={this.state.color}
+                    color={this.state.colorPickerColor}
                     onChangeComplete={this.handleChangeComplete}
                     disableAlpha
                     className="col-sm"

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -2,6 +2,7 @@ import React from "react";
 import {SketchPicker} from 'react-color';
 import {fetchPost} from "../../common";
 import SliderInstrument from "../instruments/SliderInstrument";
+import PaletteColor from "../color_encoding_to_sound/PaletteColor";
 
 class BasePage extends React.Component {
     state = {
@@ -34,8 +35,7 @@ class BasePage extends React.Component {
     render() {
         const colorDisplay = this.state.listOfColors.map( (color, i) =>
             <div key={i}>
-                <p>Color {i+1}</p>
-                <p> R: {color.r} G: {color.g} B: {color.b}</p>
+                <PaletteColor id={i} color={color} selected={false} />
             </div>
         );
         return (<div>

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -39,6 +39,10 @@ class BasePage extends React.Component {
             </div>
         );
         return (<div>
+            <h1> Color Encoding to Sound </h1>
+            <p> Use the color picker below to choose a color, and hit the submit
+            button to add up to (max) colors to your palette. When you're ready to
+            hear them together, click the Generate Instrument button to hear them together!</p>
             <SketchPicker
                 color={this.state.color}
                 onChangeComplete={this.handleChangeComplete}

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -40,9 +40,9 @@ class BasePage extends React.Component {
         );
         return (<div>
             <h1> Color Encoding to Sound </h1>
-            <p> Use the color picker below to choose a color, and hit the submit
-            button to add up to (max) colors to your palette. When you're ready to
-            hear them together, click the Generate Instrument button to hear them together!</p>
+            <p> Use the color picker below to choose a color, and hit the <b>submit</b> button
+            to add up to (max) colors to your palette. When you're ready to  hear them together,
+            click the <b>Generate Instrument</b> button to hear them together!</p>
             <SketchPicker
                 color={this.state.color}
                 onChangeComplete={this.handleChangeComplete}

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -9,63 +9,32 @@ class BasePage extends React.Component {
         super(props);
 
         this.handlePaletteClick = this.handlePaletteClick.bind(this);
+
+        // TODO(ra): can we make a nicer starting palette?
+        const NUM_COLORS = 7;
+        const initialColors = [];
+        for (let i = 0; i < NUM_COLORS; i++) {
+            const grey = {r: 125, g: 125, b: 125};
+            initialColors.push(grey);
+        }
+
         this.state = {
             result: [],
             selected: 0,
             instrumentGenerated: false,
-            colorPickerColor: {
-                    r: 51,
-                    g: 51,
-                    b: 51,
-            },
-            listOfColors: [
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                },
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                },
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                },
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                },
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                },
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                },
-                {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                }
-            ],
+            colorPickerColor: {r: 51, g: 51, b: 51},
+            listOfColors: initialColors,
         };
     }
 
     handlePaletteClick = (e) => {
-        this.setState({ selected: Number(e.target.id) });
+        this.setState({selected: Number(e.target.id)});
     }
 
     handleChangeComplete = (color) => {
-        const currentColorState = [ ...this.state.listOfColors ];
+        const currentColorState = [...this.state.listOfColors];
         currentColorState[this.state.selected] = color.rgb;
-        this.setState({ listOfColors: [ ...currentColorState ], colorPickerColor: color.rgb });
+        this.setState({listOfColors: [...currentColorState], colorPickerColor: color.rgb});
     };
 
     handleSubmit = () => {
@@ -73,7 +42,7 @@ class BasePage extends React.Component {
         const responseCallbackFunc = responseDict => {
             this.setState({
                 result: responseDict,
-                instrumentGenerated: true
+                instrumentGenerated: true,
             });
             alert("Instrument has been updated!");
         };
@@ -81,16 +50,19 @@ class BasePage extends React.Component {
     };
 
     render() {
-        const colorDisplay = this.state.listOfColors.map( (color, i) =>
-            <div key={i}>
-                    <PaletteColor id={i} color={color} selected={i===Number(this.state.selected)} handlePaletteClick={this.handlePaletteClick}/>
-            </div>
+        const colorDisplay = this.state.listOfColors.map((color, i) =>
+            <PaletteColor
+                key={i} id={i}
+                color={color}
+                selected={i === Number(this.state.selected)}
+                handlePaletteClick={this.handlePaletteClick}
+            />
         );
         return (<div>
             <h1> Color Encoding to Sound </h1>
             <p> Use the color picker below to choose a color, and hit the <b>submit</b> button
-            to add up to seven colors to your palette. When you're ready to  hear them together,
-            click the <b>Generate Instrument</b> button to hear them together!</p>
+                to add up to seven colors to your palette. When you're ready to hear them together,
+                click the <b>Generate Instrument</b> button to hear them together!</p>
             <div className="row">
                 <SketchPicker
                     color={this.state.colorPickerColor}
@@ -99,28 +71,21 @@ class BasePage extends React.Component {
                     className="col-sm"
                 />
 
-                {/*<audio controls controlsList={"nodownload"}>*/}
-                {/*        <source src={`data:audio/wav;base64,${this.state.result}`} type={"audio/wav"}/>*/}
-                {/*</audio>*/}
-                {/*<audio controls="controls"*/}
-                {/*       src={`data:audio/wav;base64, ${this.state.result}`}*/}
-                {/*       controlsList="nodownload"/>*/}
-
                 <div className="col-sm-2">
-                    { colorDisplay }
+                    {colorDisplay}
                     <button onClick={this.handleSubmit}>
-                        {this.state.instrumentGenerated ? "Update Instrument" : "Generate Instrument"}
+                        {this.state.instrumentGenerated
+                            ? "Update Instrument"
+                            : "Generate Instrument"}
                     </button>
                 </div>
 
                 <div className="col-sm">
-                    {this.state.result.length !== 0 && <SliderInstrument
-                        samples={this.state.result}
-                    />}
+                    {this.state.result.length !== 0 &&
+                    <SliderInstrument samples={this.state.result}/>}
                 </div>
             </div>
         </div>);
     }
-};
-
+}
 export default BasePage;

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -109,7 +109,7 @@ class BasePage extends React.Component {
                 {/*       src={`data:audio/wav;base64, ${this.state.result}`}*/}
                 {/*       controlsList="nodownload"/>*/}
 
-                <div className="col-sm">
+                <div className="col-sm-2">
                     { colorDisplay }
                     <button onClick={this.handleSubmit}>
                         {this.state.instrumentGenerated ? "Update Instrument" : "Generate Instrument"}

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -86,28 +86,34 @@ class BasePage extends React.Component {
             <p> Use the color picker below to choose a color, and hit the <b>submit</b> button
             to add up to (max) colors to your palette. When you're ready to  hear them together,
             click the <b>Generate Instrument</b> button to hear them together!</p>
-            <SketchPicker
-                color={this.state.color}
-                onChangeComplete={this.handleChangeComplete}
-                disableAlpha
-            />
+            <div className="row">
+                <SketchPicker
+                    color={this.state.color}
+                    onChangeComplete={this.handleChangeComplete}
+                    disableAlpha
+                    className="col-sm"
+                />
 
-            {/*<audio controls controlsList={"nodownload"}>*/}
-            {/*        <source src={`data:audio/wav;base64,${this.state.result}`} type={"audio/wav"}/>*/}
-            {/*</audio>*/}
-            {/*<audio controls="controls"*/}
-            {/*       src={`data:audio/wav;base64, ${this.state.result}`}*/}
-            {/*       controlsList="nodownload"/>*/}
+                {/*<audio controls controlsList={"nodownload"}>*/}
+                {/*        <source src={`data:audio/wav;base64,${this.state.result}`} type={"audio/wav"}/>*/}
+                {/*</audio>*/}
+                {/*<audio controls="controls"*/}
+                {/*       src={`data:audio/wav;base64, ${this.state.result}`}*/}
+                {/*       controlsList="nodownload"/>*/}
 
-            { colorDisplay }
+                <div className="col-sm">
+                    { colorDisplay }
+                    <button onClick={this.handleSubmit}>
+                        {this.state.instrumentGenerated ? "Update Instrument" : "Generate Instrument"}
+                    </button>
+                </div>
 
-            <button onClick={this.handleSubmit}>
-                {this.state.instrumentGenerated ? "Update Instrument" : "Generate Instrument"}
-            </button>
-
-            {this.state.result.length !== 0 && <SliderInstrument
-                samples={this.state.result}
-            />}
+                <div className="col-sm">
+                    {this.state.result.length !== 0 && <SliderInstrument
+                        samples={this.state.result}
+                    />}
+                </div>
+            </div>
         </div>);
     }
 };

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -75,7 +75,7 @@ class BasePage extends React.Component {
                 result: responseDict,
                 instrumentGenerated: true
             });
-            // console.log(this.state.listOfColors);
+            alert("Instrument has been updated!");
         };
         fetchPost('/api/color/', requestBody, responseCallbackFunc);
     };

--- a/frontend/components/color_encoding_to_sound/BasePage.js
+++ b/frontend/components/color_encoding_to_sound/BasePage.js
@@ -5,18 +5,66 @@ import SliderInstrument from "../instruments/SliderInstrument";
 import PaletteColor from "../color_encoding_to_sound/PaletteColor";
 
 class BasePage extends React.Component {
-    state = {
-        color: {
-            r: 51,
-            g: 51,
-            b: 51,
-        },
-        result: [],
-        listOfColors: [],
-    };
+    constructor(props) {
+        super(props);
+
+        this.handlePaletteClick = this.handlePaletteClick.bind(this);
+        this.state = {
+            color: {
+                r: 51,
+                g: 51,
+                b: 51,
+            },
+            result: [],
+            selected: 0,
+            listOfColors: [
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                },
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                },
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                },
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                },
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                },
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                },
+                {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                }
+            ],
+        };
+    }
+
+    handlePaletteClick = (e) => {
+        this.setState({ selected: e.target.id });
+    }
 
     handleChangeComplete = (color) => {
-        this.setState({color: color.rgb});
+        const currentColorState = [ ...this.state.listOfColors ];
+        currentColorState[this.state.selected] = color.rgb;
+        this.setState({ listOfColors: [ ...currentColorState ] });
     };
 
     handleSubmit = () => {
@@ -35,7 +83,7 @@ class BasePage extends React.Component {
     render() {
         const colorDisplay = this.state.listOfColors.map( (color, i) =>
             <div key={i}>
-                <PaletteColor id={i} color={color} selected={false} />
+                <PaletteColor id={i} color={color} selected={false} handlePaletteClick={this.handlePaletteClick}/>
             </div>
         );
         return (<div>
@@ -47,9 +95,9 @@ class BasePage extends React.Component {
                 color={this.state.color}
                 onChangeComplete={this.handleChangeComplete}
             />
-            <button onClick={this.handleSubmit}>
-                Submit
-            </button>
+            {/*<button onClick={this.handleSubmit}>*/}
+            {/*    Submit*/}
+            {/*</button>*/}
 
             {/*<audio controls controlsList={"nodownload"}>*/}
             {/*        <source src={`data:audio/wav;base64,${this.state.result}`} type={"audio/wav"}/>*/}
@@ -58,9 +106,9 @@ class BasePage extends React.Component {
             {/*       src={`data:audio/wav;base64, ${this.state.result}`}*/}
             {/*       controlsList="nodownload"/>*/}
 
-            <SliderInstrument
-                samples={this.state.result}
-            />
+            {/*<SliderInstrument*/}
+            {/*    samples={this.state.result}*/}
+            {/*/>*/}
 
             { colorDisplay }
         </div>);

--- a/frontend/components/color_encoding_to_sound/PaletteColor.js
+++ b/frontend/components/color_encoding_to_sound/PaletteColor.js
@@ -27,6 +27,7 @@ class PaletteColor extends React.Component {
 
         return (<div>
                 <div
+                    className='float-left'
                     id={id}
                     style={style}
                     onClick={this.props.handlePaletteClick}/>

--- a/frontend/components/color_encoding_to_sound/PaletteColor.js
+++ b/frontend/components/color_encoding_to_sound/PaletteColor.js
@@ -8,16 +8,27 @@ class PaletteColor extends React.Component {
         const color = this.props.color;
         const styleString = `background-color: rgb(${color.r},${color.g},${color.b})`;
         const id = this.props.id;
+        let style = {
+            backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
+            height: "15px",
+            width: "100px"
+        };
+
+        if (selected) {
+            style = {
+                    backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
+                    height: "15px",
+                    width: "100px",
+                    // borderStyle: "solid",
+                    // borderWidth: 1,
+                    // borderColor: 'red',
+                    boxShadow: "5px 5px 4px gray"};
+        }
+
         return (<div>
                 <div
                     id={id}
-                    style={
-                        {
-                            backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
-                            height: "15px",
-                            width: "100px"
-                        }
-                    }
+                    style={style}
                     onClick={this.props.handlePaletteClick}/>
                 <br />
         </div>);

--- a/frontend/components/color_encoding_to_sound/PaletteColor.js
+++ b/frontend/components/color_encoding_to_sound/PaletteColor.js
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+import SliderInstrument from "../instruments/SliderInstrument";
+
+class PaletteColor extends React.Component {
+    render() {
+        const selected = this.props.selected;
+        const color = this.props.color;
+        const styleString = `background-color: rgb(${color.r},${color.g},${color.b})`;
+        const id = this.props.id;
+        return (<div>
+            <input type="checkbox" id={id} />
+                <div style={
+                    {
+                        backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
+                        height: "15px",
+                        width: "100px"
+                    }
+                } />
+        </div>);
+    }
+}
+
+PaletteColor.propTypes = {
+    selected: PropTypes.bool,
+    color: PropTypes.object,
+    id: PropTypes.number
+};
+
+export default PaletteColor;

--- a/frontend/components/color_encoding_to_sound/PaletteColor.js
+++ b/frontend/components/color_encoding_to_sound/PaletteColor.js
@@ -1,41 +1,32 @@
 import React from "react";
 import PropTypes from "prop-types";
-import SliderInstrument from "../instruments/SliderInstrument";
 
-class PaletteColor extends React.Component {
-    render() {
-        const selected = this.props.selected;
-        const color = this.props.color;
-        const styleString = `background-color: rgb(${color.r},${color.g},${color.b})`;
-        const id = this.props.id;
-        let style = {
-            backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
-            height: "15px",
-            width: "100px"
-        };
+const PaletteColor = ({id, color, handlePaletteClick, selected}) => {
+    const style = {
+        backgroundColor: `rgb(${color.r},${color.g},${color.b})`,
+        height: "15px",
+        width: "100px",
+        float: "left",
+        border: 0,
+    };
 
-        if (selected) {
-            style = {
-                    ...style,
-                    boxShadow: "5px 5px 4px gray"};
-        }
-
-        return (<div>
-                <div
-                    className='float-left'
-                    id={id}
-                    style={style}
-                    onClick={this.props.handlePaletteClick}/>
-                <br />
-        </div>);
+    if (selected) {
+        style.boxShadow = "5px 5px 4px gray";
     }
-}
 
+    return (<div className="row mb-2"><div className="col">
+        <button
+            id={id}
+            style={style}
+            onClick={handlePaletteClick}
+        />
+    </div></div>);
+};
 PaletteColor.propTypes = {
-    selected: PropTypes.bool,
-    color: PropTypes.object,
     id: PropTypes.number,
-    handlePaletteClick: PropTypes.func
+    color: PropTypes.object,
+    handlePaletteClick: PropTypes.func,
+    selected: PropTypes.bool,
 };
 
 export default PaletteColor;

--- a/frontend/components/color_encoding_to_sound/PaletteColor.js
+++ b/frontend/components/color_encoding_to_sound/PaletteColor.js
@@ -16,12 +16,7 @@ class PaletteColor extends React.Component {
 
         if (selected) {
             style = {
-                    backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
-                    height: "15px",
-                    width: "100px",
-                    // borderStyle: "solid",
-                    // borderWidth: 1,
-                    // borderColor: 'red',
+                    ...style,
                     boxShadow: "5px 5px 4px gray"};
         }
 

--- a/frontend/components/color_encoding_to_sound/PaletteColor.js
+++ b/frontend/components/color_encoding_to_sound/PaletteColor.js
@@ -9,14 +9,17 @@ class PaletteColor extends React.Component {
         const styleString = `background-color: rgb(${color.r},${color.g},${color.b})`;
         const id = this.props.id;
         return (<div>
-            <input type="checkbox" id={id} />
-                <div style={
-                    {
-                        backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
-                        height: "15px",
-                        width: "100px"
+                <div
+                    id={id}
+                    style={
+                        {
+                            backgroundColor: `rgb(${color.r},${color.g},${color.b}`,
+                            height: "15px",
+                            width: "100px"
+                        }
                     }
-                } />
+                    onClick={this.props.handlePaletteClick}/>
+                <br />
         </div>);
     }
 }
@@ -24,7 +27,8 @@ class PaletteColor extends React.Component {
 PaletteColor.propTypes = {
     selected: PropTypes.bool,
     color: PropTypes.object,
-    id: PropTypes.number
+    id: PropTypes.number,
+    handlePaletteClick: PropTypes.func
 };
 
 export default PaletteColor;

--- a/frontend/components/instruments/SliderInstrument.js
+++ b/frontend/components/instruments/SliderInstrument.js
@@ -30,7 +30,7 @@ const SliderInstrument = ({samples}) => {
     for (let i = 0; i < samples.length; i++) {
         const audioElementId = `audio-${i}`;
         controllers.push(
-            <li className="list-inline-item" key={i} >
+            <li className="list-unstyled" key={i} >
                 <audio
                     autoPlay
                     loop


### PR DESCRIPTION
This PR supersedes #51 in order to fix some merge problems over there. Copying in the full PR description here:

Original PR opened by @leanneshen et al.

---

This PR allows users to create an instrument (similar to the csv ratio instrument) based on multiple chosen RGB values in a palette. The user can edit 7 colors on a palette by selecting a rectangle and changing the value on the RGB slider. Similar to the last PR for this branch, the colors are converted to energy values and converted to the frequency in the range (150, 350) Hz. After clicking on the “Generate/Update Instrument” button, an instrument volume control slider with a tone corresponding to the energy of the color is generated and the sound is played. A user can also update the colors on the color picker after the instrument is generated. 

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/22827684/140242074-60199142-2533-4242-a306-2acf40727c00.png">

Potential future design changes:
- Add borders around the rectangles of colors
- Better alignment between sliders and colors on palette
- Make rectangles white with a border to start- black looks sad :(
- Add more spacing between instrument rectangles
- Change frequency range
- Padding paragraph text for increased readability
