### PR TITLE
Add missing sonification functions to the frontend

### DIFF
--- a/backend/app/api_views.py
+++ b/backend/app/api_views.py
@@ -337,28 +337,25 @@ def time_series_to_samples(request):
 ################################################################################
 # TEXT SHAPE
 ################################################################################
-@api_view(['GET'])
+@api_view(['POST'])
 def text_shape_to_music(request):
     """
     API endpoint for generating audio based on the shape analysis of the given text
     """
-    text = request.query_params.get('text')
-    secs_per_line = float(request.query_params.get('secondsPerLine'))
-    base_freq = float(request.query_params.get('baseFreq'))
-    max_beat_freq = float(request.query_params.get('maxBeatFreq'))
+    text = request.data.get('text')
+    secs_per_line = float(request.data.get('secondsPerLine'))
+    base_freq = float(request.data.get('baseFreq'))
+    max_beat_freq = float(request.data.get('maxBeatFreq'))
     higher_second_freq = False
-    if request.query_params.get('higherSecondFreq') == 'true':
+    if request.data.get('higherSecondFreq') == 'true':
         higher_second_freq = True
 
     audio_data = text_processing.text_shape_to_sound(
         text, secs_per_line, base_freq, max_beat_freq, higher_second_freq
     )
 
-    res = {
-        'sound': audio_samples_to_wav_base64(audio_data)
-    }
-
-    return Response(res)
+    wav_file_base64 = audio_samples_to_wav_base64(audio_data)
+    return Response(wav_file_base64)
 
 
 @api_view(['POST'])
@@ -366,23 +363,20 @@ def text_shape_to_samples(request):
     """
     API endpoint for generating an instrument based on the shape analysis of the given text
     """
-    text = request.query_params.get('text')
-    secs_per_line = float(request.query_params.get('secondsPerLine'))
-    base_freq = float(request.query_params.get('baseFreq'))
-    max_beat_freq = float(request.query_params.get('maxBeatFreq'))
+    text = request.data.get('text')
+    secs_per_line = float(request.data.get('secondsPerLine'))
+    base_freq = float(request.data.get('baseFreq'))
+    max_beat_freq = float(request.data.get('maxBeatFreq'))
     higher_second_freq = False
-    if request.query_params.get('higherSecondFreq') == 'true':
+    if request.data.get('higherSecondFreq') == 'true':
         higher_second_freq = True
 
     audio_data = text_processing.text_shape_to_samples(
         text, secs_per_line, base_freq, max_beat_freq, higher_second_freq
     )
 
-    res = {
-        'sound': [audio_samples_to_wav_base64(wave) for wave in audio_data]
-    }
-
-    return Response(res)
+    samples = [audio_samples_to_wav_base64(wave) for wave in audio_data]
+    return Response(samples)
 
 
 ################################################################################

--- a/backend/app/api_views.py
+++ b/backend/app/api_views.py
@@ -92,7 +92,7 @@ def color_to_music(request):
     """
     response_object = request.data['listOfColors']
 
-    sound = None
+    raw_samples = []
     for response in response_object:
         r = response["r"]
         g = response["g"]
@@ -106,20 +106,17 @@ def color_to_music(request):
 
         audio_samples = synths.generate_sine_wave_with_envelope(
             frequency=freq_to_generate,
-            duration=1,
+            duration=3,
             a_percentage=0,
             d_percentage=0,
             s_percentage=1,
             r_percentage=0
         )
 
-        if sound is None:
-            sound = audio_samples
-        else:
-            sound += audio_samples
+        raw_samples.append(audio_samples)
 
-    wav_file_base64 = [audio_samples_to_wav_base64(sound)]
-
+    raw_audio = np.hstack(raw_samples)
+    wav_file_base64 = audio_samples_to_wav_base64(raw_audio)
     return Response(wav_file_base64)
 
 
@@ -171,10 +168,8 @@ def gesture_to_music(request):
     # pitch_range and duration_range are hardcoded for now
     # TODO: allow variable pitch/duration range inputs in the frontend
     audio = gesture_processing.convert_gesture_to_audio(gestures, gestures_params)
-    res = {
-        'sound': audio_samples_to_wav_base64(audio)
-    }
-    return Response(res)
+    wav_file_base64 = audio_samples_to_wav_base64(audio)
+    return Response(wav_file_base64)
 
 
 @api_view(['POST'])
@@ -191,7 +186,7 @@ def gesture_to_samples(request):
     for coordinate_sum in coordinate_sums:
         audio_samples = synths.generate_sine_wave_with_envelope(
             frequency=coordinate_sum,
-            duration=50,
+            duration=1,
             a_percentage=0,
             d_percentage=0,
             s_percentage=1,

--- a/frontend/components/color/ColorSonifier.js
+++ b/frontend/components/color/ColorSonifier.js
@@ -22,9 +22,9 @@ class ColorSonifier extends React.Component {
         ];
 
         this.state = {
-            result: [],
+            instrumentSamples: null,
+            music: null,
             selected: 0,
-            instrumentGenerated: false,
             colorPickerColor: initialColors[0],
             listOfColors: initialColors,
         };
@@ -42,13 +42,12 @@ class ColorSonifier extends React.Component {
 
     handleSubmit = () => {
         const requestBody = {listOfColors: this.state.listOfColors};
-        const responseCallbackFunc = responseDict => {
-            this.setState({
-                result: responseDict,
-                instrumentGenerated: true,
-            });
-        };
-        fetchPost('/api/color_to_samples/', requestBody, responseCallbackFunc);
+        // TODO(ra): doing this as a pair of API calls is a hack to get it done quickly
+        //           without a refactor -- actually refactor this in future!
+        const setSamples = response => this.setState({instrumentSamples: response});
+        const setMusic = response => this.setState({music: response});
+        fetchPost('/api/color_to_samples/', requestBody, setSamples);
+        fetchPost('/api/color_to_music/', requestBody, setMusic);
     };
 
     render() {
@@ -83,9 +82,9 @@ class ColorSonifier extends React.Component {
                             <div className="text-right">
                                 <button className="btn btn-outline-dark mt-2"
                                     onClick={this.handleSubmit}>
-                                    {this.state.instrumentGenerated
-                                        ? "Update Instrument"
-                                        : "Generate Instrument"}
+                                    {this.state.instrumentSamples
+                                        ? "Update"
+                                        : "Sonify!"}
                                 </button>
                             </div>
                         </div>
@@ -93,8 +92,11 @@ class ColorSonifier extends React.Component {
 
                     <div className="row">
                         <div className="col">
-                            {this.state.result.length !== 0 &&
-                            <InstrumentPicker samples={this.state.result}/>
+                            {this.state.instrumentSamples && this.state.music &&
+                                <InstrumentPicker
+                                    samples={this.state.instrumentSamples}
+                                    music={this.state.music}
+                                />
                             }
                         </div>
                     </div>

--- a/frontend/components/inputs/UploadTimeSeriesFileInput.js
+++ b/frontend/components/inputs/UploadTimeSeriesFileInput.js
@@ -14,7 +14,12 @@ const DEFAULT_COLUMN_CONSTANTS = {
     "r_percentage": .2,
 };
 
-const UploadTimeSeriesFileInput = ({uploadSuccessfulCallback, apiEndpoint}) => {
+const UploadTimeSeriesFileInput = ({
+    musicApiEndpoint,
+    samplesApiEndpoint,
+    setInstrumentSamples,
+    setMusicData,
+}) => {
     const [parsedCSV, setParsedCSV] = useState(null);
     const [duration, setDuration] = useState(.2);
     const [everyN, setEveryN] = useState(1);
@@ -45,7 +50,7 @@ const UploadTimeSeriesFileInput = ({uploadSuccessfulCallback, apiEndpoint}) => {
         const formData = new FormData();
         formData.append("type", "file");
         formData.append("value", file, "tempfile.csv");
-        fetchPost('/api/parse_csv/', formData, setParsedCsvAndUpdateConstants, false);
+        void fetchPost('/api/parse_csv/', formData, setParsedCsvAndUpdateConstants, false);
     };
 
     const submitToAPI = () => {
@@ -56,7 +61,8 @@ const UploadTimeSeriesFileInput = ({uploadSuccessfulCallback, apiEndpoint}) => {
             mapToNote,
             parsedCSV,
         };
-        fetchPost(apiEndpoint, requestBody, uploadSuccessfulCallback);
+        void fetchPost(musicApiEndpoint, requestBody, setMusicData);
+        void fetchPost(samplesApiEndpoint, requestBody, setInstrumentSamples);
     };
 
     const updateConstant = (colNumber, constantName, val) => {
@@ -196,8 +202,10 @@ const UploadTimeSeriesFileInput = ({uploadSuccessfulCallback, apiEndpoint}) => {
 };
 
 UploadTimeSeriesFileInput.propTypes = {
-    uploadSuccessfulCallback: PropTypes.func,
-    apiEndpoint: PropTypes.string,
+    setMusicData: PropTypes.func,
+    setInstrumentSamples: PropTypes.func,
+    musicApiEndpoint: PropTypes.string,
+    samplesApiEndpoint: PropTypes.string,
 };
 
 

--- a/frontend/components/instruments/InstrumentPicker.js
+++ b/frontend/components/instruments/InstrumentPicker.js
@@ -16,7 +16,7 @@ const DownloadSamples = ({samples}) => {
                 <li key={i} className="list-group-item">
                     <audio controls controlsList="nodownload" src={sample} />
                     <a
-                        className="btn btn-primary"
+                        className="btn btn-primary float-right"
                         download={`sample-${i}.wav`} href={sample}
                     >
                         Download
@@ -30,10 +30,39 @@ DownloadSamples.propTypes = {
     samples: PropTypes.arrayOf(PropTypes.string),
 };
 
-const InstrumentPicker = ({samples}) => {
+const MusicPlayer = ({music}) => {
+    const musicDataAsUrl = `data:audio/wav;base64, ${music}`;
+
+    return (<div>
+        <p>
+        This is a single sonification of your input data.
+        Check out the other tabs for interactive sonifications of the data.
+        </p>
+
+        <audio controls controlsList="nodownload" src={musicDataAsUrl} />
+        <br />
+        <a
+            className="btn btn-primary float-right"
+            download={`sonification.wav`} href={musicDataAsUrl}
+        >
+            Download
+        </a>
+    </div>);
+};
+MusicPlayer.propTypes = {
+    music: PropTypes.string,
+};
+
+
+
+const InstrumentPicker = ({music, samples}) => {
     const [curInstrument, setCurInstrument] = useState(0);
 
     const instruments = [
+        {
+            title: "Music",
+            component: <MusicPlayer music={music}/>,
+        },
         {
             title: "Pads",
             component: <PadInstrument samples={samples}/>,
@@ -92,6 +121,7 @@ const InstrumentPicker = ({samples}) => {
 };
 InstrumentPicker.propTypes = {
     samples: PropTypes.arrayOf(PropTypes.string),
+    music: PropTypes.string,
 };
 
 export default InstrumentPicker;

--- a/frontend/components/instruments/InstrumentPicker.js
+++ b/frontend/components/instruments/InstrumentPicker.js
@@ -35,8 +35,8 @@ const MusicPlayer = ({music}) => {
 
     return (<div>
         <p>
-        This is a single sonification of your input data.
-        Check out the other tabs for interactive sonifications of the data.
+        This is a sonification of your input data as a single piece of music.
+        Check out the other tabs for interactive sonifications of the data!
         </p>
 
         <audio controls controlsList="nodownload" src={musicDataAsUrl} />

--- a/frontend/components/textShapeToSound/TextShapeAnalysis.js
+++ b/frontend/components/textShapeToSound/TextShapeAnalysis.js
@@ -1,5 +1,7 @@
 import React, {useState} from "react";
 import STYLES from "./TextShapeAnalysis.module.scss";
+import {fetchPost} from "../../common";
+import InstrumentPicker from "../instruments/InstrumentPicker";
 
 const TextShapeAnalysis = () => {
 
@@ -7,7 +9,10 @@ const TextShapeAnalysis = () => {
     const [secondsPerLine, setSecondsPerLine] = useState(1);
     const [baseFreq, setBaseFreq] = useState(440);
     const [maxBeatFreq, setMaxBeatFreq] = useState(20);
-    const [results, setResults] = useState("");
+
+    const [music, setMusic] = useState(null);
+    const [instrumentSamples, setInstrumentSamples] = useState(null);
+
     const [higherSecondFreq, setHigherSecondFreq] = useState(false);
 
     const handleTextChange = (event) => {
@@ -78,20 +83,9 @@ const TextShapeAnalysis = () => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        setResults("");
-        const encodedText = encodeURIComponent(text);
-        const encodedSecondsPerLine = encodeURIComponent(secondsPerLine);
-        const encodedBaseFreq = encodeURIComponent(baseFreq);
-        const encodedMaxBeatFreq = encodeURIComponent(maxBeatFreq);
-        const encodedHigherSecondFreq = encodeURIComponent(higherSecondFreq);
-        fetch(`/api/text_shape_to_music/?text=${encodedText}
-        &secondsPerLine=${encodedSecondsPerLine}&baseFreq=${encodedBaseFreq}
-        &maxBeatFreq=${encodedMaxBeatFreq}
-        &higherSecondFreq=${encodedHigherSecondFreq}`)
-            .then(response => response.json())
-            .then(data => {
-                setResults(data["sound"]);
-            });
+        const requestBody = {text, secondsPerLine, baseFreq, maxBeatFreq, higherSecondFreq};
+        void fetchPost('/api/text_shape_to_music/', requestBody, setMusic);
+        void fetchPost('/api/text_shape_to_samples/', requestBody, setInstrumentSamples);
     };
 
     const makeTextInput = (heading, id, value, title, onChange, unit) => (
@@ -210,12 +204,9 @@ const TextShapeAnalysis = () => {
                     </div>
                 </div>
             </form>
-            {results && (<>
-                <h3>Play Audio:</h3>
-                <audio controls controlsList={"download"}>
-                    <source src={`data:audio/wav;base64,${results}`} type={"audio/wav"}/>
-                </audio>
-            </>)}
+            {music && instrumentSamples &&
+                <InstrumentPicker music={music} samples={instrumentSamples} />
+            }
 
         </div>
     );

--- a/frontend/components/timeSeries/TimeSeries.js
+++ b/frontend/components/timeSeries/TimeSeries.js
@@ -1,32 +1,30 @@
 import React, {useState} from "react";
 import UploadTimeSeriesFileInput from "../inputs/UploadTimeSeriesFileInput";
+import InstrumentPicker from "../instruments/InstrumentPicker";
 
 const TimeSeries = () => {
-    const [audioSample, setAudioSample] = useState(null);
+    const [instrumentSamples, setInstrumentSamples] = useState(null);
+    const [musicData, setMusicData] = useState(null);
 
     return (
         <div>
             <h1>Time Series Data</h1>
             <UploadTimeSeriesFileInput
-                uploadSuccessfulCallback={setAudioSample}
-                apiEndpoint={'/api/time_series_to_music/'}
+                setMusicData={setMusicData}
+                setInstrumentSamples={setInstrumentSamples}
+                musicApiEndpoint={'/api/time_series_to_music/'}
+                samplesApiEndpoint={'/api/time_series_to_samples/'}
             />
-            {
-                audioSample ? <>
-                    <p><b>Sound:</b></p>
-                    <audio
-                        controls
-                        autoPlay
-                        loop
-                        src={`data:audio/wav;base64, ${audioSample.sound}`}
-                        controlsList="download"
-                    />
-                    <br/>
+            {musicData &&
+                <div>
                     <img
-                        src={`data:image/png;base64, ${audioSample.img}`}
+                        src={`data:image/png;base64, ${musicData.img}`}
                         alt="A line chart showing the frequencies of the sonified data"
                     />
-                </>: null
+                </div>
+            }
+            {musicData && instrumentSamples &&
+                <InstrumentPicker music={musicData.sound} samples={instrumentSamples}/>
             }
 
         </div>

--- a/frontend/components/timeSeries/TimeSeries.js
+++ b/frontend/components/timeSeries/TimeSeries.js
@@ -22,7 +22,10 @@ const TimeSeries = () => {
                         controlsList="download"
                     />
                     <br/>
-                    <img src={`data:image/png;base64, ${audioSample.img}`}/>
+                    <img
+                        src={`data:image/png;base64, ${audioSample.img}`}
+                        alt="A line chart showing the frequencies of the sonified data"
+                    />
                 </>: null
             }
 


### PR DESCRIPTION
This PR:
- Adds a new tab to the `InstrumentPicker` for the single audio file music sonifications. Maybe `InstrumentPicker` is now a bad name?
- Implements `InstrumentPicker` in all the remaining sonification modules
- Wires up the missing sonification function for every module (i.e., for those that initially implemented single audio output, this PR adds the instrument samples version; and vice versa). n.b., the way I've done this is a total kludge but should basically be good enough for now, and we can make it better over IAP.

TODO:
- Both the polygon and time series modules have visualizations along with the sonifications, and right now those are external to the picker. Probably we want a props in the instrument picker to allow some customization for each module, but I don't think we're going to get there for today!